### PR TITLE
Vulkan: Register a debug-messenger when `VK_EXT_DEBUG_UTILS` is detected

### DIFF
--- a/include/Vulkan/Debug.hpp
+++ b/include/Vulkan/Debug.hpp
@@ -4,16 +4,6 @@
 #include <fmt/core.h>
 #include <string_view>
 
-#ifdef _MSC_VER
-#include <sal.h>
-#define VK_PRINTF_FORMAT _Printf_format_string_
-#define VK_PRINTF_FORMAT_ATTR(format_arg_index, dots_arg_index)
-#else
-#define VK_PRINTF_FORMAT
-#define VK_PRINTF_FORMAT_ATTR(format_arg_index, dots_arg_index)                \
-	__attribute__((__format__(__printf__, format_arg_index, dots_arg_index)))
-#endif
-
 namespace Vulkan
 {
 

--- a/include/Vulkan/Debug.hpp
+++ b/include/Vulkan/Debug.hpp
@@ -17,6 +17,8 @@
 namespace Vulkan
 {
 
+vk::UniqueDebugUtilsMessengerEXT CreateDebugMessenger(vk::Instance Instance);
+
 void SetObjectName(
 	vk::Device Device, vk::ObjectType ObjectType, const void* ObjectHandle,
 	std::string_view ObjectName

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -64,10 +64,10 @@ static VKAPI_ATTR vk::Bool32 VKAPI_CALL DebugMessengerCallback(
 	const vk::DebugUtilsMessengerCallbackDataEXT* CallbackData, void* UserData
 )
 {
-	std::printf(
-		"[\033[%um%s\033[0m]\033[%um%s\033[0m: %s\n", SeverityColor(Severity),
-		vk::to_string(Severity).c_str(), MessageTypeColor(Type),
-		vk::to_string(Type).c_str(), CallbackData->pMessage
+	fmt::println(
+		"[\033[{}m{}\033[0m]\033[{}m{}\033[0m: {}", SeverityColor(Severity),
+		vk::to_string(Severity), MessageTypeColor(Type), vk::to_string(Type),
+		CallbackData->pMessage
 	);
 
 	switch( Severity )

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -8,6 +8,56 @@
 
 namespace
 {
+std::uint8_t SeverityColor(vk::DebugUtilsMessageSeverityFlagBitsEXT Severity)
+{
+	switch( Severity )
+	{
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
+	{
+		// Dark Gray
+		return 90u;
+	}
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
+	{
+		// Light Gray
+		return 90u;
+	}
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
+	{
+		// Light Magenta
+		return 95u;
+	}
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
+	{
+		// Light red
+		return 91u;
+	}
+	}
+	// Default Foreground Color
+	return 39u;
+}
+
+std::uint8_t MessageTypeColor(vk::DebugUtilsMessageTypeFlagsEXT MessageType)
+{
+	if( MessageType & vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral )
+	{
+		// Dim
+		return 2u;
+	}
+	if( MessageType & vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance )
+	{
+		// Bold/Bright
+		return 1u;
+	}
+	if( MessageType & vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation )
+	{
+		// Light Gray
+		return 90u;
+	}
+	// Default Foreground Color
+	return 39u;
+}
+
 static VKAPI_ATTR vk::Bool32 VKAPI_CALL DebugMessengerCallback(
 	vk::DebugUtilsMessageSeverityFlagBitsEXT      Severity,
 	vk::DebugUtilsMessageTypeFlagsEXT             Type,
@@ -15,7 +65,8 @@ static VKAPI_ATTR vk::Bool32 VKAPI_CALL DebugMessengerCallback(
 )
 {
 	std::printf(
-		"[%s]%s: %s\n", vk::to_string(Severity).c_str(),
+		"[\033[%um%s\033[0m]\033[%um%s\033[0m: %s\n", SeverityColor(Severity),
+		vk::to_string(Severity).c_str(), MessageTypeColor(Type),
 		vk::to_string(Type).c_str(), CallbackData->pMessage
 	);
 

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -6,8 +6,101 @@
 #include <cstdio>
 #include <memory>
 
+namespace
+{
+static VKAPI_ATTR vk::Bool32 VKAPI_CALL DebugMessengerCallback(
+	vk::DebugUtilsMessageSeverityFlagBitsEXT      Severity,
+	vk::DebugUtilsMessageTypeFlagsEXT             Type,
+	const vk::DebugUtilsMessengerCallbackDataEXT* CallbackData, void* UserData
+)
+{
+	std::printf(
+		"[%s]%s: %s\n", vk::to_string(Severity).c_str(),
+		vk::to_string(Type).c_str(), CallbackData->pMessage
+	);
+
+	return false;
+}
+
+static VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessengerCallback(
+	VkDebugUtilsMessageSeverityFlagBitsEXT      Severity,
+	VkDebugUtilsMessageTypeFlagsEXT             Type,
+	const VkDebugUtilsMessengerCallbackDataEXT* CallbackData, void* UserData
+)
+{
+	return DebugMessengerCallback(
+		vk::DebugUtilsMessageSeverityFlagBitsEXT{Severity},
+		vk::DebugUtilsMessageTypeFlagsEXT{Type},
+		reinterpret_cast<const vk::DebugUtilsMessengerCallbackDataEXT*>(
+			CallbackData
+		),
+		UserData
+	);
+}
+} // namespace
+
 namespace Vulkan
 {
+
+vk::UniqueDebugUtilsMessengerEXT CreateDebugMessenger(vk::Instance Instance)
+{
+	std::vector<vk::ExtensionProperties> InstanceExtensionProperties;
+
+	if( const auto EnumerateResult = vk::enumerateInstanceExtensionProperties();
+		EnumerateResult.result == vk::Result::eSuccess )
+	{
+		InstanceExtensionProperties = EnumerateResult.value;
+	}
+	else
+	{
+		// Error enumerating instance extensions
+		return {};
+	}
+
+	const auto it = std::find_if(
+		InstanceExtensionProperties.begin(), InstanceExtensionProperties.end(),
+		[](const vk::ExtensionProperties& ExtensionProperties) {
+			return std::strcmp(
+					   VK_EXT_DEBUG_UTILS_EXTENSION_NAME,
+					   ExtensionProperties.extensionName
+				   )
+				== 0;
+		}
+	);
+
+	if( it == InstanceExtensionProperties.end() )
+	{
+		// Does not support VK_EXT_DEBUG_UTILS
+		return {};
+	}
+	// VK_EXT_DEBUG_UTILS supported
+
+	// Create debug messenger
+
+	vk::DebugUtilsMessengerCreateInfoEXT DebugMessengerInfo = {};
+	DebugMessengerInfo.messageSeverity
+		= vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo
+		| vk::DebugUtilsMessageSeverityFlagBitsEXT::eError
+		| vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning
+		| vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose;
+	DebugMessengerInfo.messageType
+		= vk::DebugUtilsMessageTypeFlagBitsEXT::eGeneral
+		| vk::DebugUtilsMessageTypeFlagBitsEXT::eValidation
+		| vk::DebugUtilsMessageTypeFlagBitsEXT::eDeviceAddressBinding
+		| vk::DebugUtilsMessageTypeFlagBitsEXT::ePerformance;
+
+	DebugMessengerInfo.pfnUserCallback = DebugMessengerCallback;
+
+	if( auto CreateResult
+		= Instance.createDebugUtilsMessengerEXTUnique(DebugMessengerInfo);
+		CreateResult.result == vk::Result::eSuccess )
+	{
+		return std::move(CreateResult.value);
+	}
+	// Error creating debug utils messenger
+	return {};
+}
+
 void SetObjectName(
 	vk::Device Device, vk::ObjectType ObjectType, const void* ObjectHandle,
 	std::string_view ObjectName

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -70,6 +70,18 @@ static VKAPI_ATTR vk::Bool32 VKAPI_CALL DebugMessengerCallback(
 		vk::to_string(Type).c_str(), CallbackData->pMessage
 	);
 
+	switch( Severity )
+	{
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eVerbose:
+		break;
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eInfo:
+		break;
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eWarning:
+		break;
+	case vk::DebugUtilsMessageSeverityFlagBitsEXT::eError:
+		break;
+	}
+
 	return false;
 }
 

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -80,8 +80,8 @@ static VKAPI_ATTR VkBool32 VKAPI_CALL DebugMessengerCallback(
 )
 {
 	return DebugMessengerCallback(
-		vk::DebugUtilsMessageSeverityFlagBitsEXT{Severity},
-		vk::DebugUtilsMessageTypeFlagsEXT{Type},
+		vk::DebugUtilsMessageSeverityFlagBitsEXT(Severity),
+		vk::DebugUtilsMessageTypeFlagsEXT(Type),
 		reinterpret_cast<const vk::DebugUtilsMessengerCallbackDataEXT*>(
 			CallbackData
 		),

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -178,6 +178,10 @@ int main(int argc, char* argv[])
 	}
 	VULKAN_HPP_DEFAULT_DISPATCHER.init(Instance.get());
 
+	//// Register debug messenger
+	const vk::UniqueDebugUtilsMessengerEXT DebugMessenger
+		= Vulkan::CreateDebugMessenger(Instance.get());
+
 	//// Pick physical device
 	vk::PhysicalDevice PhysicalDevice = {};
 


### PR DESCRIPTION
Conditionally register a debug messenger callback
to handle debug-message events from the driver or validation layer.