### PR TITLE
Vulkan: Refactor debug-formatting to `libfmt`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "external/glm"]
 	path = external/glm
 	url = git@github.com:g-truc/glm.git
+[submodule "external/fmt"]
+	path = external/fmt
+	url = git@github.com:fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,18 @@ find_package(
 
 find_package( Threads REQUIRED )
 
+#cmrc
+include( external/cmrc/CMakeRC.cmake )
+
+
+#fmt
+find_package(fmt REQUIRED)
+if( fmt_FOUND )
+else()
+	add_subdirectory( external/fmt EXCLUDE_FROM_ALL )
+endif()
+
+#glm
 find_package( glm 0.9.9.9 QUIET )
 
 if( glm_FOUND )
@@ -93,9 +105,6 @@ endif()
 
 # mio
 add_subdirectory( external/mio EXCLUDE_FROM_ALL )
-
-#cmrc
-include( external/cmrc/CMakeRC.cmake )
 
 ### shaders build target
 file(
@@ -245,6 +254,7 @@ target_link_libraries(
 	blam
 	Vulkan::Vulkan
 	mio::mio
+	fmt
 	glm
 	${CMAKE_DL_LIBS}
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ include( external/cmrc/CMakeRC.cmake )
 
 
 #fmt
-find_package(fmt REQUIRED)
+find_package(fmt QUIET)
 if( fmt_FOUND )
 else()
 	add_subdirectory( external/fmt EXCLUDE_FROM_ALL )

--- a/include/Vulkan/Debug.hpp
+++ b/include/Vulkan/Debug.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <Vulkan/VulkanAPI.hpp>
-#include <format>
+#include <fmt/core.h>
 #include <string_view>
 
 #ifdef _MSC_VER
@@ -38,34 +38,34 @@ concept VulkanHandleType = vk::isVulkanHandleType<T>::value;
 template<VulkanHandleType T, typename... ArgsT>
 inline void SetObjectName(
 	vk::Device Device, const T ObjectHandle,
-	std::format_string<ArgsT...> Format, ArgsT&&... Args
+	fmt::format_string<ArgsT...> Format, ArgsT&&... Args
 )
 {
 	SetObjectName(
 		Device, T::objectType, ObjectHandle,
-		std::format(Format, std::forward<ArgsT>(Args)...)
+		fmt::format(Format, std::forward<ArgsT>(Args)...)
 	);
 }
 
 template<typename... ArgsT>
 void BeginDebugLabel(
 	vk::CommandBuffer CommandBuffer, const std::array<float, 4>& Color,
-	std::format_string<ArgsT...> Format, ArgsT&&... Args
+	fmt::format_string<ArgsT...> Format, ArgsT&&... Args
 )
 {
 	BeginDebugLabel(
-		CommandBuffer, Color, std::format(Format, std::forward<ArgsT>(Args)...)
+		CommandBuffer, Color, fmt::format(Format, std::forward<ArgsT>(Args)...)
 	);
 }
 
 template<typename... ArgsT>
 void InsertDebugLabel(
 	vk::CommandBuffer CommandBuffer, const std::array<float, 4>& Color,
-	std::format_string<ArgsT...> Format, ArgsT&&... Args
+	fmt::format_string<ArgsT...> Format, ArgsT&&... Args
 )
 {
 	InsertDebugLabel(
-		CommandBuffer, Color, std::format(Format, std::forward<ArgsT>(Args)...)
+		CommandBuffer, Color, fmt::format(Format, std::forward<ArgsT>(Args)...)
 	);
 }
 
@@ -80,26 +80,26 @@ public:
 	template<typename... ArgsT>
 	DebugLabelScope(
 		vk::CommandBuffer           TargetCommandBuffer,
-		const std::array<float, 4>& Color, std::format_string<ArgsT...> Format,
+		const std::array<float, 4>& Color, fmt::format_string<ArgsT...> Format,
 		ArgsT&&... Args
 	)
 		: CommandBuffer(TargetCommandBuffer)
 	{
 		BeginDebugLabel(
 			CommandBuffer, Color,
-			std::format(Format, std::forward<ArgsT>(Args)...)
+			fmt::format(Format, std::forward<ArgsT>(Args)...)
 		);
 	}
 
 	template<typename... ArgsT>
 	void operator()(
-		const std::array<float, 4>& Color, std::format_string<ArgsT...> Format,
+		const std::array<float, 4>& Color, fmt::format_string<ArgsT...> Format,
 		ArgsT&&... Args
 	) const
 	{
 		InsertDebugLabel(
 			CommandBuffer, Color,
-			std::format(Format, std::forward<ArgsT>(Args)...)
+			fmt::format(Format, std::forward<ArgsT>(Args)...)
 		);
 	}
 

--- a/include/Vulkan/Debug.hpp
+++ b/include/Vulkan/Debug.hpp
@@ -2,9 +2,6 @@
 
 #include <Vulkan/VulkanAPI.hpp>
 
-#include <type_traits>
-#include <utility>
-
 #ifdef _MSC_VER
 #include <sal.h>
 #define VK_PRINTF_FORMAT _Printf_format_string_
@@ -24,10 +21,10 @@ void SetObjectName(
 	VK_PRINTF_FORMAT const char* Format, ...
 );
 
-template<
-	typename T,
-	typename = std::enable_if_t<vk::isVulkanHandleType<T>::value == true>,
-	typename... ArgsT>
+template<typename T>
+concept VulkanHandleType = vk::isVulkanHandleType<T>::value;
+
+template<VulkanHandleType T, typename... ArgsT>
 inline void SetObjectName(
 	vk::Device Device, const T ObjectHandle,
 	VK_PRINTF_FORMAT const char* Format, ArgsT&&... Args

--- a/include/Vulkan/Debug.hpp
+++ b/include/Vulkan/Debug.hpp
@@ -30,10 +30,13 @@ inline void SetObjectName(
 	VK_PRINTF_FORMAT const char* Format, ArgsT&&... Args
 )
 {
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 	SetObjectName(
 		Device, T::objectType, ObjectHandle, Format,
 		std::forward<ArgsT>(Args)...
 	);
+#pragma GCC diagnostic pop
 }
 
 VK_PRINTF_FORMAT_ATTR(3, 4)
@@ -64,9 +67,12 @@ public:
 	)
 		: CommandBuffer(TargetCommandBuffer)
 	{
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-security"
 		BeginDebugLabel(
 			CommandBuffer, Color, Format, std::forward<ArgsT>(Args)...
 		);
+#pragma GCC diagnostic pop
 	}
 
 	template<typename... ArgsT>

--- a/source/VkBlam/Scene.cpp
+++ b/source/VkBlam/Scene.cpp
@@ -263,7 +263,7 @@ void Scene::Render(const SceneView& View, vk::CommandBuffer CommandBuffer)
 	{
 		const auto& CurLightmapMesh = LightmapMeshs[i];
 		Vulkan::InsertDebugLabel(
-			CommandBuffer, {0.5, 0.5, 0.5, 1.0}, "BSP Draw: %zu", i
+			CommandBuffer, {0.5, 0.5, 0.5, 1.0}, "BSP Draw: {}", i
 		);
 
 		// Bind Shader descriptors
@@ -565,8 +565,8 @@ std::optional<Scene>
 
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, NewScene.BSPVertexBuffer.get(),
-			"VkBlam::Scene: BSP Vertex Buffer( %s )",
-			Common::FormatByteCount(BSPVertexBufferInfo.size).c_str()
+			"VkBlam::Scene: BSP Vertex Buffer( {} )",
+			Common::FormatByteCount(BSPVertexBufferInfo.size)
 		);
 
 		//// Create Vertex buffer heap
@@ -596,8 +596,8 @@ std::optional<Scene>
 
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, NewScene.BSPLightmapVertexBuffer.get(),
-			"VkBlam::Scene: BSP Lightmap Vertex Buffer( %s )",
-			Common::FormatByteCount(BSPLightmapVertexBufferInfo.size).c_str()
+			"VkBlam::Scene: BSP Lightmap Vertex Buffer( {} )",
+			Common::FormatByteCount(BSPLightmapVertexBufferInfo.size)
 		);
 
 		//// Create Index buffer heap
@@ -623,8 +623,8 @@ std::optional<Scene>
 		}
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, NewScene.BSPIndexBuffer.get(),
-			"VkBlam::Scene: BSP Index Buffer( %s )",
-			Common::FormatByteCount(BSPIndexBufferInfo.size).c_str()
+			"VkBlam::Scene: BSP Index Buffer( {} )",
+			Common::FormatByteCount(BSPIndexBufferInfo.size)
 		);
 
 		// Create singular allocation of device memory for all vertex and index
@@ -650,8 +650,8 @@ std::optional<Scene>
 		}
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, NewScene.BSPGeometryMemory.get(),
-			"VkBlam::Scene: BSP Geometry Device Memory( %s )",
-			Common::FormatByteCount(BSPIndexBufferInfo.size).c_str()
+			"VkBlam::Scene: BSP Geometry Device Memory( {} )",
+			Common::FormatByteCount(BSPIndexBufferInfo.size)
 		);
 
 		// Buffers are all now binded to device memory, begin streaming
@@ -772,8 +772,8 @@ std::optional<Scene>
 
 				Vulkan::SetObjectName(
 					VulkanContext.LogicalDevice, BitmapDest.Image.get(),
-					"VkBlam::Scene: Bitmap %08X[%2zu] | %s", TagEntry.TagID,
-					CurSubTextureIdx, Map.GetTagName(TagEntry.TagID).data()
+					"VkBlam::Scene: Bitmap {:08X}[{:2}] | {}", TagEntry.TagID,
+					CurSubTextureIdx, Map.GetTagName(TagEntry.TagID)
 				);
 			}
 		};
@@ -994,11 +994,9 @@ std::optional<Scene>
 					Vulkan::SetObjectName(
 						TargetRenderer.GetVulkanContext().LogicalDevice,
 						BitmapDest.View.get(),
-						"VkBlam::Scene: Bitmap View %08X[%2zu] | %s",
+						"VkBlam::Scene: Bitmap View {:08X}[{:2}] | {}",
 						TagEntry.TagID, CurSubTextureIdx,
-						TargetWorld.GetMapFile()
-							.GetTagName(TagEntry.TagID)
-							.data()
+						TargetWorld.GetMapFile().GetTagName(TagEntry.TagID)
 					);
 
 					// Create descriptor set
@@ -1023,11 +1021,10 @@ std::optional<Scene>
 					Vulkan::SetObjectName(
 						TargetRenderer.GetVulkanContext().LogicalDevice,
 						TargetSet,
-						"VkBlam::Scene: Bitmap Descriptor Set %08X[%2zu] | %s",
+						"VkBlam::Scene: Bitmap Descriptor Set {:08X}[{:2}] | "
+						"{}",
 						TagEntry.TagID, CurSubTextureIdx,
-						TargetWorld.GetMapFile()
-							.GetTagName(TagEntry.TagID)
-							.data()
+						TargetWorld.GetMapFile().GetTagName(TagEntry.TagID)
 					);
 
 					TargetRenderer.GetDescriptorUpdateBatch().AddImage(
@@ -1071,8 +1068,8 @@ std::optional<Scene>
 
 			Vulkan::SetObjectName(
 				VulkanContext.LogicalDevice, NewSet,
-				"senv: %08X \'%s\' Descriptor Set", TagEntry.TagID,
-				TargetWorld.GetMapFile().GetTagName(TagEntry.TagID).data()
+				"senv: {:08X} \'{}\' Descriptor Set", TagEntry.TagID,
+				TargetWorld.GetMapFile().GetTagName(TagEntry.TagID)
 			);
 
 			const vk::ImageView BaseMapView

--- a/source/Vulkan/Debug.cpp
+++ b/source/Vulkan/Debug.cpp
@@ -10,33 +10,13 @@ namespace Vulkan
 {
 void SetObjectName(
 	vk::Device Device, vk::ObjectType ObjectType, const void* ObjectHandle,
-	const char* Format, ...
+	std::string_view ObjectName
 )
 {
-	va_list Args;
-	va_start(Args, Format);
-	const auto NameLength = std::vsnprintf(nullptr, 0, Format, Args);
-	va_end(Args);
-	if( NameLength < 0 )
-	{
-		// Invalid vsnprintf
-		return;
-	}
-
-	std::unique_ptr<char[]> ObjectName
-		= std::make_unique<char[]>(std::size_t(NameLength) + 1u);
-
-	// Write formatted object name
-	va_start(Args, Format);
-	std::vsnprintf(
-		ObjectName.get(), std::size_t(NameLength) + 1u, Format, Args
-	);
-	va_end(Args);
-
 	vk::DebugUtilsObjectNameInfoEXT NameInfo = {};
 	NameInfo.objectType                      = ObjectType;
 	NameInfo.objectHandle = reinterpret_cast<std::uintptr_t>(ObjectHandle);
-	NameInfo.pObjectName  = ObjectName.get();
+	NameInfo.pObjectName  = ObjectName.data();
 
 	if( Device.setDebugUtilsObjectNameEXT(NameInfo) != vk::Result::eSuccess )
 	{
@@ -46,31 +26,11 @@ void SetObjectName(
 
 void BeginDebugLabel(
 	vk::CommandBuffer CommandBuffer, const std::array<float, 4>& Color,
-	const char* Format, ...
+	std::string_view LabelName
 )
 {
-	va_list Args;
-	va_start(Args, Format);
-	const auto NameLength = std::vsnprintf(nullptr, 0, Format, Args);
-	va_end(Args);
-	if( NameLength < 0 )
-	{
-		// Invalid vsnprintf
-		return;
-	}
-
-	std::unique_ptr<char[]> ObjectName
-		= std::make_unique<char[]>(std::size_t(NameLength) + 1u);
-
-	// Write formatted object name
-	va_start(Args, Format);
-	std::vsnprintf(
-		ObjectName.get(), std::size_t(NameLength) + 1u, Format, Args
-	);
-	va_end(Args);
-
 	vk::DebugUtilsLabelEXT LabelInfo = {};
-	LabelInfo.pLabelName             = ObjectName.get();
+	LabelInfo.pLabelName             = LabelName.data();
 	LabelInfo.color[0]               = Color[0];
 	LabelInfo.color[1]               = Color[1];
 	LabelInfo.color[2]               = Color[2];
@@ -81,31 +41,11 @@ void BeginDebugLabel(
 
 void InsertDebugLabel(
 	vk::CommandBuffer CommandBuffer, const std::array<float, 4>& Color,
-	const char* Format, ...
+	std::string_view LabelName
 )
 {
-	va_list Args;
-	va_start(Args, Format);
-	const auto NameLength = std::vsnprintf(nullptr, 0, Format, Args);
-	va_end(Args);
-	if( NameLength < 0 )
-	{
-		// Invalid vsnprintf
-		return;
-	}
-
-	std::unique_ptr<char[]> ObjectName
-		= std::make_unique<char[]>(std::size_t(NameLength) + 1u);
-
-	// Write formatted object name
-	va_start(Args, Format);
-	std::vsnprintf(
-		ObjectName.get(), std::size_t(NameLength) + 1u, Format, Args
-	);
-	va_end(Args);
-
 	vk::DebugUtilsLabelEXT LabelInfo = {};
-	LabelInfo.pLabelName             = ObjectName.get();
+	LabelInfo.pLabelName             = LabelName.data();
 	LabelInfo.color[0]               = Color[0];
 	LabelInfo.color[1]               = Color[1];
 	LabelInfo.color[2]               = Color[2];

--- a/source/Vulkan/StreamBuffer.cpp
+++ b/source/Vulkan/StreamBuffer.cpp
@@ -75,8 +75,8 @@ StreamBuffer::StreamBuffer(
 		}
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, RingBuffer.get(),
-			"StreamBuffer: Ring Buffer( %s )",
-			Common::FormatByteCount(BufferSize).c_str()
+			"StreamBuffer: Ring Buffer( {} )",
+			Common::FormatByteCount(BufferSize)
 		);
 	}
 
@@ -129,8 +129,8 @@ StreamBuffer::StreamBuffer(
 		}
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, RingBufferMemory.get(),
-			"StreamBuffer: Ring Buffer Memory( %s )",
-			Common::FormatByteCount(BufferSize).c_str()
+			"StreamBuffer: Ring Buffer Memory( {} )",
+			Common::FormatByteCount(BufferSize)
 		);
 
 		if( auto BindResult = VulkanContext.LogicalDevice.bindBufferMemory(
@@ -412,7 +412,7 @@ std::uint64_t StreamBuffer::Flush()
 
 		Vulkan::SetObjectName(
 			VulkanContext.LogicalDevice, FlushCommandBuffer,
-			"StreamBuffer: Command Buffer %zu", CommandBuffers.size()
+			"StreamBuffer: Command Buffer {}", CommandBuffers.size()
 		);
 	}
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -325,8 +325,8 @@ int main(int argc, char* argv[])
 	}
 
 	Vulkan::SetObjectName(
-		Device.get(), StagingBuffer.get(), "Staging Buffer( %s )",
-		Common::FormatByteCount(StagingBufferInfo.size).c_str()
+		Device.get(), StagingBuffer.get(), "Staging Buffer( {} )",
+		Common::FormatByteCount(StagingBufferInfo.size)
 	);
 
 	// Allocate memory for staging buffer


### PR DESCRIPTION
Provides better compile-time type-safety and diagnostic information than `va_list`-based formatting.