### PR TITLE
Vulkan: Implement a `QueryPool`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,6 +255,7 @@ add_executable(
 	source/Vulkan/DescriptorUpdateBatch.cpp
 	source/Vulkan/Memory.cpp
 	source/Vulkan/Pipeline.cpp
+	source/Vulkan/QueryPool.cpp
 	source/Vulkan/SamplerCache.cpp
 	source/Vulkan/ShaderModuleCache.cpp
 	source/Vulkan/StreamBuffer.cpp

--- a/include/Vulkan/QueryPool.hpp
+++ b/include/Vulkan/QueryPool.hpp
@@ -1,0 +1,69 @@
+#pragma once
+
+#include <Vulkan/VulkanAPI.hpp>
+
+#include <vector>
+
+namespace Vulkan
+{
+
+class QueryPool
+{
+private:
+	const Vulkan::Context& VulkanContext;
+
+	const vk::QueryType        QueryType;
+	const std::size_t          QueryCount;
+	std::vector<std::uint64_t> QueryData;
+	std::vector<bool>          QueryActive;
+
+	vk::UniqueQueryPool Pool;
+
+public:
+	QueryPool(
+		const Vulkan::Context& VulkanContext, vk::QueryType QueryType,
+		std::size_t QueryCount = 256
+	);
+	~QueryPool();
+
+	void BeginQuery(vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex);
+	void EndQuery(vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex);
+
+	void WriteTimestamp(
+		vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex,
+		vk::PipelineStageFlagBits PipelineStage
+		= vk::PipelineStageFlagBits::eAllCommands
+	);
+
+	// Uses RAII to handle the aquiring of a query and reporting its
+	// results when it is available
+	struct QueryScope
+	{
+		std::size_t       QueryIndex;
+		vk::CommandBuffer TargetCommandBuffer;
+	};
+
+	QueryScope CreateQueryScope(vk::CommandBuffer CommandBuffer);
+
+	struct TimestampScope
+	{
+		std::size_t               QueryIndexStart;
+		std::size_t               QueryIndexEnd;
+		vk::PipelineStageFlagBits PipelineStage;
+		vk::CommandBuffer         TargetCommandBuffer;
+	};
+
+	TimestampScope CreateTimestampScope(
+		vk::CommandBuffer         CommandBuffer,
+		vk::PipelineStageFlagBits PipelineStage
+		= vk::PipelineStageFlagBits::eAllCommands
+	);
+};
+
+/*
+extern template class QueryPool<vk::QueryType::eOcclusion>;
+extern template class QueryPool<vk::QueryType::ePipelineStatistics>;
+extern template class QueryPool<vk::QueryType::eTimestamp>;
+*/
+
+} // namespace Vulkan

--- a/include/Vulkan/QueryPool.hpp
+++ b/include/Vulkan/QueryPool.hpp
@@ -2,11 +2,14 @@
 
 #include <Vulkan/VulkanAPI.hpp>
 
+#include <optional>
 #include <vector>
 
 namespace Vulkan
 {
 
+// Simple management class for a query pool of a specific query-type.
+// To be utilized by other types for profiling
 class QueryPool
 {
 private:
@@ -26,35 +29,21 @@ public:
 	);
 	~QueryPool();
 
+	[[nodiscard]] std::optional<std::size_t> FindFreeQuery() const;
+	[[nodiscard]] std::optional<std::size_t> AllocateFreeQuery();
+
+	void FlushActiveQuerys();
+
+	// Depending on the type of query, will return a span of either 1 value or
+	// multiple values
+	[[nodiscard]] std::optional<std::span<std::uint64_t>>
+		GetQuery(std::size_t QueryIndex);
+
 	void BeginQuery(vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex);
 	void EndQuery(vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex);
 
 	void WriteTimestamp(
 		vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex,
-		vk::PipelineStageFlagBits PipelineStage
-		= vk::PipelineStageFlagBits::eAllCommands
-	);
-
-	// Uses RAII to handle the aquiring of a query and reporting its
-	// results when it is available
-	struct QueryScope
-	{
-		std::size_t       QueryIndex;
-		vk::CommandBuffer TargetCommandBuffer;
-	};
-
-	QueryScope CreateQueryScope(vk::CommandBuffer CommandBuffer);
-
-	struct TimestampScope
-	{
-		std::size_t               QueryIndexStart;
-		std::size_t               QueryIndexEnd;
-		vk::PipelineStageFlagBits PipelineStage;
-		vk::CommandBuffer         TargetCommandBuffer;
-	};
-
-	TimestampScope CreateTimestampScope(
-		vk::CommandBuffer         CommandBuffer,
 		vk::PipelineStageFlagBits PipelineStage
 		= vk::PipelineStageFlagBits::eAllCommands
 	);

--- a/source/Vulkan/QueryPool.cpp
+++ b/source/Vulkan/QueryPool.cpp
@@ -1,0 +1,212 @@
+#include <Vulkan/QueryPool.hpp>
+
+#include <cmath>
+#include <fmt/core.h>
+namespace
+{
+constexpr vk::QueryPipelineStatisticFlags PIPELINE_STATISTICS_ALL_GRAPHICS
+	= vk::QueryPipelineStatisticFlagBits::eInputAssemblyVertices
+	| vk::QueryPipelineStatisticFlagBits::eInputAssemblyPrimitives
+	| vk::QueryPipelineStatisticFlagBits::eVertexShaderInvocations
+	| vk::QueryPipelineStatisticFlagBits::eGeometryShaderInvocations
+	| vk::QueryPipelineStatisticFlagBits::eGeometryShaderPrimitives
+	| vk::QueryPipelineStatisticFlagBits::eClippingInvocations
+	| vk::QueryPipelineStatisticFlagBits::eClippingPrimitives
+	| vk::QueryPipelineStatisticFlagBits::eFragmentShaderInvocations;
+
+constexpr std::size_t PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT
+	= std::popcount(static_cast<std::uint32_t>(PIPELINE_STATISTICS_ALL_GRAPHICS)
+	);
+
+// Number of 32-bit or 64-bit elements that an individual query occupies
+constexpr std::size_t GetQueryElementCount(
+	vk::QueryType                   QueryType,
+	vk::QueryPipelineStatisticFlags PipelineStatisticFlags
+)
+{
+	std::size_t QueryItemCount = 0;
+	switch( QueryType )
+	{
+	case vk::QueryType::eOcclusion:
+		QueryItemCount = 1;
+		break;
+	case vk::QueryType::ePipelineStatistics:
+		QueryItemCount
+			= std::popcount(static_cast<std::uint32_t>(PipelineStatisticFlags));
+		break;
+	case vk::QueryType::eTimestamp:
+		QueryItemCount = 1;
+		break;
+	default:
+		break;
+	}
+
+	return QueryItemCount;
+}
+
+// Size, in bytes, that an individual 64-bit query of this type will need
+constexpr std::size_t GetQueryElementSize(
+	vk::QueryType                   QueryType,
+	vk::QueryPipelineStatisticFlags PipelineStatisticFlags = {}
+)
+{
+	return sizeof(std::uint64_t)
+		 * GetQueryElementCount(QueryType, PipelineStatisticFlags);
+}
+
+void PrintPipelineStats(std::span<const std::uint64_t> QueryData)
+{
+	std::uint32_t CurStatMask
+		= static_cast<std::uint32_t>(PIPELINE_STATISTICS_ALL_GRAPHICS);
+
+	for( std::size_t i = 0; i < PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT; ++i )
+	{
+		// Get lowest set bit
+		const std::uint32_t CurBit = (-CurStatMask) & CurStatMask;
+		fmt::println(
+			"\t{:32}:{}",
+			vk::to_string(vk::QueryPipelineStatisticFlagBits(CurBit)),
+			QueryData[i]
+		);
+
+		// Clear lowest bit
+		CurStatMask &= ~CurBit;
+	}
+}
+
+void PrintTimelineStats(
+	std::span<const std::uint64_t> TimeStamps, std::double_t TimestampPeriod
+)
+{
+	for( const std::uint64_t& TimeStamp : TimeStamps )
+	{
+		fmt::println("\t{} ns", TimeStamp * TimestampPeriod);
+	}
+}
+
+// Detect runs of "true" values in a std::vector<bool> and call a function
+// with the starting-index and count of each run
+void IterateRuns(const std::vector<bool>& BitMask, auto&& Proc)
+{
+	for( std::size_t i = 0; i < BitMask.size(); i++ )
+	{
+		if( BitMask[i] == true )
+		{
+			const std::size_t RunStart = i;
+			std::size_t       RunCount = 1;
+			while( i < BitMask.size() - 1 && BitMask[i] == BitMask[i + 1] )
+			{
+				RunCount++;
+				i++;
+			}
+			Proc(RunStart, RunCount);
+		}
+	}
+}
+
+} // namespace
+
+namespace Vulkan
+{
+
+QueryPool::QueryPool(
+	const Vulkan::Context& VulkanContext, vk::QueryType QueryType,
+	std::size_t QueryCount
+)
+	: VulkanContext(VulkanContext), QueryType(QueryType),
+	  QueryCount(QueryCount),
+	  QueryData(
+		  GetQueryElementCount(QueryType, PIPELINE_STATISTICS_ALL_GRAPHICS)
+		  * QueryCount
+	  ),
+	  QueryActive(QueryCount)
+{
+
+	vk::QueryPoolCreateInfo PoolInfo = {};
+	PoolInfo.queryType               = QueryType;
+	PoolInfo.queryCount              = QueryCount;
+	PoolInfo.pipelineStatistics      = PIPELINE_STATISTICS_ALL_GRAPHICS;
+
+	if( auto CreateResult
+		= VulkanContext.LogicalDevice.createQueryPoolUnique(PoolInfo);
+		CreateResult.result == vk::Result::eSuccess )
+	{
+		Pool = std::move(CreateResult.value);
+	}
+}
+
+QueryPool::~QueryPool()
+{
+	// Testing
+	IterateRuns(
+		QueryActive,
+		[this](std::size_t CurQueryIndex, std::size_t CurQueryCount) {
+			const std::size_t QueryDataStride = GetQueryElementSize(
+				QueryType, PIPELINE_STATISTICS_ALL_GRAPHICS
+			);
+			const std::size_t QueryDataSize = QueryDataStride * CurQueryCount;
+
+			if( const auto GetResult
+				= VulkanContext.LogicalDevice.getQueryPoolResults(
+					Pool.get(), CurQueryIndex, CurQueryCount, QueryDataSize,
+					QueryData.data() + CurQueryIndex, QueryDataStride,
+					vk::QueryResultFlagBits::e64
+						| vk::QueryResultFlagBits::eWait
+				);
+				GetResult == vk::Result::eSuccess )
+			{
+				switch( QueryType )
+				{
+				case vk::QueryType::eOcclusion:
+					break;
+				case vk::QueryType::ePipelineStatistics:
+					fmt::println("{}", CurQueryIndex);
+					PrintPipelineStats(std::span(QueryData).subspan(
+						CurQueryIndex * PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT,
+						PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT
+					));
+					break;
+				case vk::QueryType::eTimestamp:
+					PrintTimelineStats(
+						std::span(QueryData).subspan(
+							CurQueryIndex, CurQueryCount
+						),
+						VulkanContext.PhysicalDevice.getProperties()
+							.limits.timestampPeriod
+					);
+					break;
+				default:
+					break;
+				}
+			}
+		}
+	);
+}
+
+void QueryPool::BeginQuery(
+	vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex
+)
+{
+	CommandBuffer.resetQueryPool(Pool.get(), QueryIndex, 1);
+	CommandBuffer.beginQuery(Pool.get(), QueryIndex, {});
+	QueryActive[QueryIndex] = true;
+}
+
+void QueryPool::EndQuery(
+	vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex
+)
+{
+	CommandBuffer.endQuery(Pool.get(), QueryIndex);
+}
+
+void QueryPool::WriteTimestamp(
+	vk::CommandBuffer CommandBuffer, std::uint32_t QueryIndex,
+	vk::PipelineStageFlagBits PipelineStage
+)
+{
+	CommandBuffer.resetQueryPool(Pool.get(), QueryIndex, 1);
+	CommandBuffer.writeTimestamp(PipelineStage, Pool.get(), QueryIndex);
+	QueryActive[QueryIndex] = true;
+}
+
+} // namespace Vulkan

--- a/source/Vulkan/QueryPool.cpp
+++ b/source/Vulkan/QueryPool.cpp
@@ -122,10 +122,11 @@ QueryPool::QueryPool(
 	  QueryActive(QueryCount)
 {
 
-	vk::QueryPoolCreateInfo PoolInfo = {};
-	PoolInfo.queryType               = QueryType;
-	PoolInfo.queryCount              = QueryCount;
-	PoolInfo.pipelineStatistics      = PIPELINE_STATISTICS_ALL_GRAPHICS;
+	const vk::QueryPoolCreateInfo PoolInfo = {
+		.queryType          = QueryType,
+		.queryCount         = QueryCount,
+		.pipelineStatistics = PIPELINE_STATISTICS_ALL_GRAPHICS,
+	};
 
 	if( auto CreateResult
 		= VulkanContext.LogicalDevice.createQueryPoolUnique(PoolInfo);

--- a/source/Vulkan/QueryPool.cpp
+++ b/source/Vulkan/QueryPool.cpp
@@ -54,24 +54,38 @@ constexpr std::size_t GetQueryElementSize(
 		 * GetQueryElementCount(QueryType, PipelineStatisticFlags);
 }
 
-void PrintPipelineStats(std::span<const std::uint64_t> QueryData)
+template<typename BitTypeT, typename ValueTypeT>
+void IterateFlagData(
+	vk::Flags<BitTypeT> BitFlags, std::span<const ValueTypeT> QueryData,
+	auto&& Proc
+)
 {
-	std::uint32_t CurStatMask
-		= static_cast<std::uint32_t>(PIPELINE_STATISTICS_ALL_GRAPHICS);
+	using MaskType   = vk::Flags<BitTypeT>::MaskType;
+	MaskType CurMask = static_cast<std::uint32_t>(BitFlags);
 
-	for( std::size_t i = 0; i < PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT; ++i )
+	const std::size_t BitCount = static_cast<std::size_t>(
+		std::popcount(static_cast<MaskType>(BitFlags))
+	);
+
+	for( std::size_t i = 0; i < BitCount; ++i )
 	{
 		// Get lowest set bit
-		const std::uint32_t CurBit = (-CurStatMask) & CurStatMask;
-		fmt::println(
-			"\t{:32}:{}",
-			vk::to_string(vk::QueryPipelineStatisticFlagBits(CurBit)),
-			QueryData[i]
-		);
-
+		const MaskType CurBit = (-CurMask) & CurMask;
+		Proc(BitTypeT(CurBit), QueryData[i]);
 		// Clear lowest bit
-		CurStatMask &= ~CurBit;
+		CurMask &= ~CurBit;
 	}
+}
+
+void PrintPipelineStats(std::span<const std::uint64_t> QueryData)
+{
+	IterateFlagData(
+		PIPELINE_STATISTICS_ALL_GRAPHICS, QueryData,
+		[](vk::QueryPipelineStatisticFlagBits PipelineBit,
+		   const std::uint64_t&               QueryValue) {
+			fmt::println("\t{:32}:{}", vk::to_string(PipelineBit), QueryValue);
+		}
+	);
 }
 
 void PrintTimelineStats(
@@ -90,7 +104,8 @@ void IterateRuns(const std::vector<bool>& BitMask, auto&& Proc)
 {
 	for( std::size_t i = 0; i < BitMask.size(); i++ )
 	{
-		if( BitMask[i] == true )
+		// Todo: Detect batches faster with 'clz'
+		if( BitMask[i] )
 		{
 			const std::size_t RunStart = i;
 			std::size_t       RunCount = 1;
@@ -124,7 +139,7 @@ QueryPool::QueryPool(
 
 	const vk::QueryPoolCreateInfo PoolInfo = {
 		.queryType          = QueryType,
-		.queryCount         = QueryCount,
+		.queryCount         = static_cast<std::uint32_t>(QueryCount),
 		.pipelineStatistics = PIPELINE_STATISTICS_ALL_GRAPHICS,
 	};
 
@@ -139,6 +154,64 @@ QueryPool::QueryPool(
 QueryPool::~QueryPool()
 {
 	// Testing
+	FlushActiveQuerys();
+	IterateRuns(
+		QueryActive,
+		[this](std::size_t CurQueryIndex, std::size_t CurQueryCount) {
+			switch( QueryType )
+			{
+			case vk::QueryType::eOcclusion:
+				break;
+			case vk::QueryType::ePipelineStatistics:
+				fmt::println("{}", CurQueryIndex);
+				PrintPipelineStats(std::span(QueryData).subspan(
+					CurQueryIndex * PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT,
+					PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT
+				));
+				break;
+			case vk::QueryType::eTimestamp:
+				PrintTimelineStats(
+					std::span(QueryData).subspan(CurQueryIndex, CurQueryCount),
+					VulkanContext.PhysicalDevice.getProperties()
+						.limits.timestampPeriod
+				);
+				break;
+			default:
+				break;
+			}
+		}
+	);
+}
+
+std::optional<std::size_t> QueryPool::FindFreeQuery() const
+{
+	// Todo: A faster 'clz'-based method for finding free slots
+	for( std::size_t i = 0; i < QueryActive.size(); ++i )
+	{
+		if( !QueryActive[i] )
+		{
+			return i;
+		}
+	}
+
+	return std::nullopt;
+}
+
+std::optional<std::size_t> QueryPool::AllocateFreeQuery()
+{
+	if( const auto FreeSlot = FindFreeQuery(); FreeSlot.has_value() )
+	{
+		QueryActive[FreeSlot.value()] = true;
+		QueryData[FreeSlot.value()]   = {};
+		return FreeSlot.value();
+	}
+
+	return std::nullopt;
+}
+
+void QueryPool::FlushActiveQuerys()
+{
+	// Flush query in batches
 	IterateRuns(
 		QueryActive,
 		[this](std::size_t CurQueryIndex, std::size_t CurQueryCount) {
@@ -156,31 +229,38 @@ QueryPool::~QueryPool()
 				);
 				GetResult == vk::Result::eSuccess )
 			{
-				switch( QueryType )
-				{
-				case vk::QueryType::eOcclusion:
-					break;
-				case vk::QueryType::ePipelineStatistics:
-					fmt::println("{}", CurQueryIndex);
-					PrintPipelineStats(std::span(QueryData).subspan(
-						CurQueryIndex * PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT,
-						PIPELINE_STATISTICS_ALL_GRAPHICS_COUNT
-					));
-					break;
-				case vk::QueryType::eTimestamp:
-					PrintTimelineStats(
-						std::span(QueryData).subspan(
-							CurQueryIndex, CurQueryCount
-						),
-						VulkanContext.PhysicalDevice.getProperties()
-							.limits.timestampPeriod
-					);
-					break;
-				default:
-					break;
-				}
+				// Error flushing query
 			}
 		}
+	);
+}
+
+std::optional<std::span<std::uint64_t>>
+	QueryPool::GetQuery(std::size_t QueryIndex)
+{
+	if( QueryIndex >= QueryCount )
+	{
+		// Invalid index
+		return std::nullopt;
+	}
+
+	const std::size_t QueryDataCount
+		= GetQueryElementCount(QueryType, PIPELINE_STATISTICS_ALL_GRAPHICS);
+	const std::size_t QueryDataStride = QueryDataCount * sizeof(std::uint64_t);
+
+	if( const auto GetResult = VulkanContext.LogicalDevice.getQueryPoolResults(
+			Pool.get(), QueryIndex, 1, QueryDataStride,
+			QueryData.data() + QueryIndex, QueryDataStride,
+			vk::QueryResultFlagBits::e64 | vk::QueryResultFlagBits::eWait
+		);
+		GetResult != vk::Result::eSuccess )
+	{
+		// Error getting query data
+		return std::nullopt;
+	}
+
+	return std::span(QueryData).subspan(
+		QueryDataCount * QueryIndex, QueryDataCount
 	);
 }
 

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -732,14 +732,17 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
-	Vulkan::QueryPool BenchPool(VulkanContext, vk::QueryType::eTimestamp);
+	Vulkan::QueryPool TimestampPool(VulkanContext, vk::QueryType::eTimestamp);
+	Vulkan::QueryPool PipelinePool(
+		VulkanContext, vk::QueryType::ePipelineStatistics
+	);
 
 	{
 		Vulkan::DebugLabelScope FrameScope(
 			CommandBuffer.get(), {1.0, 0.0, 1.0, 1.0}, "Frame"
 		);
-		BenchPool.WriteTimestamp(CommandBuffer.get(), 0);
-		// BenchPool.BeginQuery(CommandBuffer.get(), 0);
+		TimestampPool.WriteTimestamp(CommandBuffer.get(), 0);
+		PipelinePool.BeginQuery(CommandBuffer.get(), 0);
 
 		{
 			Vulkan::DebugLabelScope RenderPassScope(
@@ -840,9 +843,8 @@ int main(int argc, char* argv[])
 			);
 		}
 
-		// BenchPool.EndQuery(CommandBuffer.get(), 0);
-
-		BenchPool.WriteTimestamp(CommandBuffer.get(), 1);
+		PipelinePool.EndQuery(CommandBuffer.get(), 0);
+		TimestampPool.WriteTimestamp(CommandBuffer.get(), 1);
 	}
 
 	if( auto EndResult = CommandBuffer->end();
@@ -912,6 +914,9 @@ int main(int argc, char* argv[])
 		);
 		return EXIT_FAILURE;
 	}
+
+	const auto Test1 = PipelinePool.GetQuery(0).value();
+	const auto Test2 = TimestampPool.GetQuery(0).value();
 
 #ifdef CAPTURE
 	if( rdoc_api )

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -16,6 +16,7 @@
 #include <Vulkan/DescriptorHeap.hpp>
 #include <Vulkan/Memory.hpp>
 #include <Vulkan/Pipeline.hpp>
+#include <Vulkan/QueryPool.hpp>
 #include <Vulkan/VulkanAPI.hpp>
 
 #include <VkBlam/Rasterizer.hpp>
@@ -731,10 +732,14 @@ int main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
+	Vulkan::QueryPool BenchPool(VulkanContext, vk::QueryType::eTimestamp);
+
 	{
 		Vulkan::DebugLabelScope FrameScope(
 			CommandBuffer.get(), {1.0, 0.0, 1.0, 1.0}, "Frame"
 		);
+		BenchPool.WriteTimestamp(CommandBuffer.get(), 0);
+		// BenchPool.BeginQuery(CommandBuffer.get(), 0);
 
 		{
 			Vulkan::DebugLabelScope RenderPassScope(
@@ -834,6 +839,10 @@ int main(int argc, char* argv[])
 				}}
 			);
 		}
+
+		// BenchPool.EndQuery(CommandBuffer.get(), 0);
+
+		BenchPool.WriteTimestamp(CommandBuffer.get(), 1);
 	}
 
 	if( auto EndResult = CommandBuffer->end();


### PR DESCRIPTION
Implements a `Vulkan::QueryPool` type to easily maintain a vulkan QueryPool type.
A key feature is to have a `RAII`-based way to operate timestamp and pipeline-statistics similar to how `DebugScope` works.