### PR TITLE
VkBlam: Implement basic Block-heap for `bitm` texture allocations

### DIFF
--- a/include/VkBlam/Tags/Implementations/Bitmap.hpp
+++ b/include/VkBlam/Tags/Implementations/Bitmap.hpp
@@ -43,14 +43,19 @@ private:
 
 	// All of these images are static textures that only ever get sample from,
 	// so a simple heap-allocator is utilized
+	// Minimum requirements for Halo CE is 64MiB of VRAM, so this should
+	// be a good block-size
 	static constexpr std::uint64_t BlockSize = 64_MiB;
-	static_assert(std::has_single_bit(BlockSize), "BlockSize must be pow2");
+	static_assert(
+		std::has_single_bit(BlockSize), "BlockSize must be a power of two"
+	);
 
 	std::vector<std::uint32_t>          BlockFreeSpace;
 	std::vector<std::uint8_t>           BlockMemoryIndex;
 	std::vector<vk::UniqueDeviceMemory> BlockMemory;
 
-	vk::BindImageMemoryInfo FindFreeBlock(vk::Image);
+	// Todo: std::expected
+	std::optional<vk::BindImageMemoryInfo> FindFreeBlock(vk::Image Image);
 
 	std::vector<std::unique_ptr<Bitmap>> Bitmaps;
 

--- a/include/VkBlam/Tags/Implementations/Bitmap.hpp
+++ b/include/VkBlam/Tags/Implementations/Bitmap.hpp
@@ -3,16 +3,17 @@
 #include "../TagImplementation.hpp"
 
 #include <Blam/Tags.hpp>
+#include <Common/Literals.hpp>
 
+#include <bit>
 #include <vector>
 
 namespace VkBlam::Tags
 {
-
+using namespace Common::Literals;
 class Bitmap final : public TagImplementation<Blam::TagClass::Bitmap>
 {
 private:
-	vk::UniqueDeviceMemory Memory;
 	struct SubBitmap
 	{
 		vk::UniqueImage     Image;
@@ -39,6 +40,17 @@ class BitmapSubsystem final
 {
 private:
 	const Vulkan::Context& VulkanContext;
+
+	// All of these images are static textures that only ever get sample from,
+	// so a simple heap-allocator is utilized
+	static constexpr std::uint64_t BlockSize = 32_MiB;
+	static_assert(std::has_single_bit(BlockSize), "BlockSize must be pow2");
+
+	std::vector<std::uint32_t>          BlockFreeSpace;
+	std::vector<std::uint8_t>           BlockMemoryIndex;
+	std::vector<vk::UniqueDeviceMemory> BlockMemory;
+
+	vk::BindImageMemoryInfo FindFreeBlock(vk::Image);
 
 	std::vector<std::unique_ptr<Bitmap>> Bitmaps;
 

--- a/include/VkBlam/Tags/Implementations/Bitmap.hpp
+++ b/include/VkBlam/Tags/Implementations/Bitmap.hpp
@@ -43,7 +43,7 @@ private:
 
 	// All of these images are static textures that only ever get sample from,
 	// so a simple heap-allocator is utilized
-	static constexpr std::uint64_t BlockSize = 32_MiB;
+	static constexpr std::uint64_t BlockSize = 64_MiB;
 	static_assert(std::has_single_bit(BlockSize), "BlockSize must be pow2");
 
 	std::vector<std::uint32_t>          BlockFreeSpace;

--- a/source/VkBlam/Tags/Implementations/Bitmap.cpp
+++ b/source/VkBlam/Tags/Implementations/Bitmap.cpp
@@ -1,6 +1,9 @@
 #include <VkBlam/Format.hpp>
 #include <VkBlam/Tags/Implementations/Bitmap.hpp>
 
+#include <Common/Alignment.hpp>
+#include <Common/Format.hpp>
+
 #include <Vulkan/Memory.hpp>
 
 namespace VkBlam::Tags
@@ -37,6 +40,93 @@ BitmapSubsystem::BitmapSubsystem(
 
 BitmapSubsystem::~BitmapSubsystem()
 {
+}
+
+vk::BindImageMemoryInfo BitmapSubsystem::FindFreeBlock(vk::Image Image)
+{
+	const vk::PhysicalDevice& PhysicalDevice = VulkanContext.PhysicalDevice;
+	// Align the incoming memory-size to bufferImageGranularity
+	const vk::DeviceSize BufferImageGranularity
+		= PhysicalDevice.getProperties().limits.bufferImageGranularity;
+
+	vk::MemoryRequirements ImageRequirements
+		= VulkanContext.LogicalDevice.getImageMemoryRequirements(Image);
+
+	ImageRequirements.size
+		= Common::AlignUp(ImageRequirements.size, BufferImageGranularity);
+
+	// Find free space in a block
+	for( std::size_t i = 0; i < BlockFreeSpace.size(); ++i )
+	{
+		std::uint32_t&      CurBlockFreeSpace   = BlockFreeSpace[i];
+		const std::uint8_t& CurBlockMemoryIndex = BlockMemoryIndex[i];
+
+		const std::uint32_t CurBlockOffStart = (BlockSize - CurBlockFreeSpace);
+
+		const std::uint32_t CurBlockOffStartAlign
+			= Common::AlignUp(CurBlockOffStart, ImageRequirements.alignment);
+
+		const std::uint32_t CurBlockOffEnd
+			= CurBlockOffStartAlign + ImageRequirements.size;
+
+		// Found a space
+		const bool ValidMemoryIndex
+			= (ImageRequirements.memoryTypeBits & 1 << CurBlockMemoryIndex)
+		   != 0u;
+
+		if( ValidMemoryIndex && CurBlockOffEnd < BlockSize )
+		{
+			CurBlockFreeSpace = BlockSize - CurBlockOffEnd;
+			return vk::BindImageMemoryInfo{
+				.image        = Image,
+				.memory       = BlockMemory[i].get(),
+				.memoryOffset = CurBlockOffStartAlign,
+			};
+		}
+	}
+
+	// No free block found, create a new one
+	const std::size_t NewBlockIndex = BlockFreeSpace.size();
+	BlockFreeSpace.emplace_back(BlockSize) -= ImageRequirements.size;
+
+	// Allocate a new block
+	const vk::Device& Device = VulkanContext.LogicalDevice;
+
+	const std::int32_t MemoryTypeIndex = Vulkan::FindMemoryTypeIndex(
+		PhysicalDevice, ImageRequirements.memoryTypeBits,
+		vk::MemoryPropertyFlagBits::eDeviceLocal
+	);
+	if( MemoryTypeIndex < 0 )
+	{
+		// Unable to find any qualifying memory
+	}
+
+	const vk::MemoryAllocateInfo BlockAllocInfo = {
+		.allocationSize  = BlockSize,
+		.memoryTypeIndex = std::uint32_t(MemoryTypeIndex),
+	};
+
+	if( auto AllocResult = Device.allocateMemoryUnique(BlockAllocInfo);
+		AllocResult.result == vk::Result::eSuccess )
+	{
+		BlockMemoryIndex.emplace_back(MemoryTypeIndex);
+		BlockMemory.emplace_back(std::move(AllocResult.value));
+	}
+	else
+	{
+		// Error allocating new block
+	}
+
+	Vulkan::SetObjectName(
+		VulkanContext.LogicalDevice, BlockMemory[NewBlockIndex].get(),
+		"Bitmap Memory Block #{:02}", NewBlockIndex
+	);
+
+	return vk::BindImageMemoryInfo{
+		.image        = Image,
+		.memory       = BlockMemory[NewBlockIndex].get(),
+		.memoryOffset = 0,
+	};
 }
 
 Bitmap* BitmapSubsystem::LoadTag(
@@ -111,36 +201,55 @@ Bitmap* BitmapSubsystem::LoadTag(
 	}
 
 	// Create a single heap of device memory for all the subimages
-	{
-		std::vector<vk::Image> Images;
-		for( const auto& Bitmap : NewBitmap->Bitmaps )
-		{
-			Images.push_back(Bitmap.Image.get());
-		}
+	// {
+	// 	std::vector<vk::Image> Images;
+	// 	for( const auto& Bitmap : NewBitmap->Bitmaps )
+	// 	{
+	// 		Images.push_back(Bitmap.Image.get());
+	// 	}
 
-		if( auto [Result, Value] = Vulkan::CommitImageHeap(
-				VulkanContext.LogicalDevice, VulkanContext.PhysicalDevice,
-				Images, vk::MemoryPropertyFlagBits::eDeviceLocal
-			);
-			Result == vk::Result::eSuccess )
-		{
-			NewBitmap->Memory = std::move(Value);
-		}
-		else
-		{
-			std::fprintf(
-				stderr, "Error committing image memory: %s\n",
-				vk::to_string(Result).c_str()
-			);
-			return nullptr;
-		}
+	// 	if( auto [Result, Value] = Vulkan::CommitImageHeap(
+	// 			VulkanContext.LogicalDevice, VulkanContext.PhysicalDevice,
+	// 			Images, vk::MemoryPropertyFlagBits::eDeviceLocal
+	// 		);
+	// 		Result == vk::Result::eSuccess )
+	// 	{
+	// 		NewBitmap->Memory = std::move(Value);
+	// 	}
+	// 	else
+	// 	{
+	// 		std::fprintf(
+	// 			stderr, "Error committing image memory: %s\n",
+	// 			vk::to_string(Result).c_str()
+	// 		);
+	// 		return nullptr;
+	// 	}
+	// }
+
+	// Vulkan::SetObjectName(
+	// 	VulkanContext.LogicalDevice, NewBitmap->Memory.get(),
+	// 	"Bitmap[{:08X}]: DeviceMemory | {}", TagIndexEntry.TagID,
+	// 	TargetScene.GetMapFile().GetTagPath(TagIndexEntry.TagID)
+	// );
+
+	// Bind bitmaps to memory
+	std::vector<vk::BindImageMemoryInfo> ImageHeapBinds;
+	for( const auto& Bitmap : NewBitmap->Bitmaps )
+	{
+		ImageHeapBinds.emplace_back(FindFreeBlock(Bitmap.Image.get()));
 	}
 
-	Vulkan::SetObjectName(
-		VulkanContext.LogicalDevice, NewBitmap->Memory.get(),
-		"Bitmap[{:08X}]: DeviceMemory | {}", TagIndexEntry.TagID,
-		TargetScene.GetMapFile().GetTagPath(TagIndexEntry.TagID)
-	);
+	// Now bind them all in one call
+	if( const vk::Result BindResult
+		= VulkanContext.LogicalDevice.bindImageMemory2(ImageHeapBinds);
+		BindResult == vk::Result::eSuccess )
+	{
+		// Binding memory succeeded
+	}
+	else
+	{
+		// Error binding memory
+	}
 
 	// Image is binded to memory now
 	// Stream image, create image view, etc

--- a/source/VkBlam/Tags/Implementations/Bitmap.cpp
+++ b/source/VkBlam/Tags/Implementations/Bitmap.cpp
@@ -42,7 +42,8 @@ BitmapSubsystem::~BitmapSubsystem()
 {
 }
 
-vk::BindImageMemoryInfo BitmapSubsystem::FindFreeBlock(vk::Image Image)
+std::optional<vk::BindImageMemoryInfo>
+	BitmapSubsystem::FindFreeBlock(vk::Image Image)
 {
 	const vk::PhysicalDevice& PhysicalDevice = VulkanContext.PhysicalDevice;
 	// Align the incoming memory-size to bufferImageGranularity
@@ -86,8 +87,12 @@ vk::BindImageMemoryInfo BitmapSubsystem::FindFreeBlock(vk::Image Image)
 	}
 
 	// No free block found, create a new one
+	// If the image is larger than the block size(?!) then just give it a whole
+	// block large enough to satisfy the allocation
 	const std::size_t NewBlockIndex = BlockFreeSpace.size();
-	BlockFreeSpace.emplace_back(BlockSize) -= ImageRequirements.size;
+	const std::size_t NewBlockSize
+		= std::max(ImageRequirements.size, BlockSize);
+	BlockFreeSpace.emplace_back(NewBlockSize) -= NewBlockSize;
 
 	// Allocate a new block
 	const vk::Device& Device = VulkanContext.LogicalDevice;
@@ -96,13 +101,15 @@ vk::BindImageMemoryInfo BitmapSubsystem::FindFreeBlock(vk::Image Image)
 		PhysicalDevice, ImageRequirements.memoryTypeBits,
 		vk::MemoryPropertyFlagBits::eDeviceLocal
 	);
+
 	if( MemoryTypeIndex < 0 )
 	{
 		// Unable to find any qualifying memory
+		return std::nullopt;
 	}
 
 	const vk::MemoryAllocateInfo BlockAllocInfo = {
-		.allocationSize  = BlockSize,
+		.allocationSize  = NewBlockSize,
 		.memoryTypeIndex = std::uint32_t(MemoryTypeIndex),
 	};
 
@@ -115,6 +122,7 @@ vk::BindImageMemoryInfo BitmapSubsystem::FindFreeBlock(vk::Image Image)
 	else
 	{
 		// Error allocating new block
+		return std::nullopt;
 	}
 
 	Vulkan::SetObjectName(
@@ -200,43 +208,20 @@ Bitmap* BitmapSubsystem::LoadTag(
 		NewBitmap->Bitmaps[CurSubTextureIdx] = std::move(CurSubBitmap);
 	}
 
-	// Create a single heap of device memory for all the subimages
-	// {
-	// 	std::vector<vk::Image> Images;
-	// 	for( const auto& Bitmap : NewBitmap->Bitmaps )
-	// 	{
-	// 		Images.push_back(Bitmap.Image.get());
-	// 	}
-
-	// 	if( auto [Result, Value] = Vulkan::CommitImageHeap(
-	// 			VulkanContext.LogicalDevice, VulkanContext.PhysicalDevice,
-	// 			Images, vk::MemoryPropertyFlagBits::eDeviceLocal
-	// 		);
-	// 		Result == vk::Result::eSuccess )
-	// 	{
-	// 		NewBitmap->Memory = std::move(Value);
-	// 	}
-	// 	else
-	// 	{
-	// 		std::fprintf(
-	// 			stderr, "Error committing image memory: %s\n",
-	// 			vk::to_string(Result).c_str()
-	// 		);
-	// 		return nullptr;
-	// 	}
-	// }
-
-	// Vulkan::SetObjectName(
-	// 	VulkanContext.LogicalDevice, NewBitmap->Memory.get(),
-	// 	"Bitmap[{:08X}]: DeviceMemory | {}", TagIndexEntry.TagID,
-	// 	TargetScene.GetMapFile().GetTagPath(TagIndexEntry.TagID)
-	// );
-
 	// Bind bitmaps to memory
 	std::vector<vk::BindImageMemoryInfo> ImageHeapBinds;
 	for( const auto& Bitmap : NewBitmap->Bitmaps )
 	{
-		ImageHeapBinds.emplace_back(FindFreeBlock(Bitmap.Image.get()));
+		if( const auto& AllocateInfo = FindFreeBlock(Bitmap.Image.get());
+			AllocateInfo.has_value() )
+		{
+			ImageHeapBinds.emplace_back(AllocateInfo.value());
+		}
+		else
+		{
+			// Error allocating space for image
+			return nullptr;
+		}
 	}
 
 	// Now bind them all in one call
@@ -249,6 +234,7 @@ Bitmap* BitmapSubsystem::LoadTag(
 	else
 	{
 		// Error binding memory
+		return nullptr;
 	}
 
 	// Image is binded to memory now
@@ -271,7 +257,7 @@ Bitmap* BitmapSubsystem::LoadTag(
 		const std::size_t LayerCount
 			= CurBitmapEntry.Type == Blam::BitmapEntryType::CubeMap ? 6 : 1;
 
-		const std::size_t BlockSize
+		const std::size_t FormatBlockSize
 			= vk::blockSize(VkBlam::BlamToVk(CurBitmapEntry.Format));
 		const std::array<std::uint8_t, 3> BlockExtent
 			= vk::blockExtent(VkBlam::BlamToVk(CurBitmapEntry.Format));
@@ -294,7 +280,7 @@ Bitmap* BitmapSubsystem::LoadTag(
 
 				const std::size_t CurPixelDataSize
 					= CurBlockCount[0] * CurBlockCount[1] * CurBlockCount[2]
-					* BlockSize;
+					* FormatBlockSize;
 
 				TargetScene.GetRasterizer().GetStreamBuffer().QueueImageUpload(
 					PixelData.subspan(PixelDataOff, CurPixelDataSize),


### PR DESCRIPTION
Rather than give each bitmap tag its own device-memory allocation, fixed-sized blocks of memory will be allocated up-front from which sub-allocations are made.

All of these images are statically sampled images that should be utilizing their own special local allocator rather than a more global general-allocator.